### PR TITLE
Add Gemini 2.5 Flash model and async chat

### DIFF
--- a/pib_api/flask/commands.py
+++ b/pib_api/flask/commands.py
@@ -125,16 +125,11 @@ def _create_chat_data_and_assistant() -> None:
         has_image_support=True,
     )
     gemini_text = AssistantModel(
-        visual_name="Gemini 2.5 Flash [Text]",
+        visual_name="Gemini 2.5 Flash",
         api_name="gemini-2.5-flash",
         has_image_support=False,
     )
-    gemini_vision = AssistantModel(
-        visual_name="Gemini 2.5 Flash [Vision]",
-        api_name="gemini-2.5-flash",
-        has_image_support=True,
-    )
-    db.session.add_all([gpt4o2, gpt4o1, gpt3, claude, gemini_text, gemini_vision])
+    db.session.add_all([gpt4o2, gpt4o1, gpt3, claude, gemini_text])
     db.session.flush()
 
     p_eva = Personality(

--- a/pib_api/flask/commands.py
+++ b/pib_api/flask/commands.py
@@ -124,7 +124,17 @@ def _create_chat_data_and_assistant() -> None:
         api_name="anthropic.claude-3-sonnet-20240229-v1:0",
         has_image_support=True,
     )
-    db.session.add_all([gpt4o2, gpt4o1, gpt3, claude])
+    gemini_text = AssistantModel(
+        visual_name="Gemini 2.5 Flash [Text]",
+        api_name="gemini-2.5-flash",
+        has_image_support=False,
+    )
+    gemini_vision = AssistantModel(
+        visual_name="Gemini 2.5 Flash [Vision]",
+        api_name="gemini-2.5-flash",
+        has_image_support=True,
+    )
+    db.session.add_all([gpt4o2, gpt4o1, gpt3, claude, gemini_text, gemini_vision])
     db.session.flush()
 
     p_eva = Personality(

--- a/pib_api/flask/migrations/versions/ba9e8ed1e18c_add_gemini_assistant_model.py
+++ b/pib_api/flask/migrations/versions/ba9e8ed1e18c_add_gemini_assistant_model.py
@@ -1,0 +1,48 @@
+"""add gemini assistant model
+
+Revision ID: ba9e8ed1e18c
+Revises: ddd0daa8e6f5
+Create Date: 2025-07-25 12:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "ba9e8ed1e18c"
+down_revision = "ddd0daa8e6f5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    result = conn.execute(sa.text("SELECT COUNT(*) FROM assistant_model"))
+    count = result.scalar()
+    if count > 0:
+        conn.execute(
+            sa.text(
+                """
+                INSERT OR IGNORE INTO assistant_model (api_name, visual_name, has_image_support)
+                VALUES ('gemini-2.5-flash', 'Gemini 2.5 Flash [Text]', false)
+                """
+            )
+        )
+        conn.execute(
+            sa.text(
+                """
+                INSERT OR IGNORE INTO assistant_model (api_name, visual_name, has_image_support)
+                VALUES ('gemini-2.5-flash', 'Gemini 2.5 Flash [Vision]', true)
+                """
+            )
+        )
+
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "DELETE FROM assistant_model WHERE visual_name IN ('Gemini 2.5 Flash [Text]', 'Gemini 2.5 Flash [Vision]')"
+        )
+    )

--- a/pib_api/flask/migrations/versions/ba9e8ed1e18c_add_gemini_assistant_model.py
+++ b/pib_api/flask/migrations/versions/ba9e8ed1e18c_add_gemini_assistant_model.py
@@ -25,15 +25,7 @@ def upgrade():
             sa.text(
                 """
                 INSERT OR IGNORE INTO assistant_model (api_name, visual_name, has_image_support)
-                VALUES ('gemini-2.5-flash', 'Gemini 2.5 Flash [Text]', false)
-                """
-            )
-        )
-        conn.execute(
-            sa.text(
-                """
-                INSERT OR IGNORE INTO assistant_model (api_name, visual_name, has_image_support)
-                VALUES ('gemini-2.5-flash', 'Gemini 2.5 Flash [Vision]', true)
+                VALUES ('gemini-2.5-flash', 'Gemini 2.5 Flash', false)
                 """
             )
         )
@@ -43,6 +35,6 @@ def downgrade():
     conn = op.get_bind()
     conn.execute(
         sa.text(
-            "DELETE FROM assistant_model WHERE visual_name IN ('Gemini 2.5 Flash [Text]', 'Gemini 2.5 Flash [Vision]')"
+            "DELETE FROM assistant_model WHERE visual_name = 'Gemini 2.5 Flash'"
         )
     )

--- a/ros_packages/requirements.txt
+++ b/ros_packages/requirements.txt
@@ -6,3 +6,4 @@ opencv-python >= 4.5.1.48
 depthai>=2.24.0.0
 numpy==1.26.3
 blobconverter==1.4.2
+google-generativeai

--- a/ros_packages/voice_assistant/package.xml
+++ b/ros_packages/voice_assistant/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>google-cloud-texttospeech</exec_depend>
   <exec_depend>pyaudio</exec_depend>
   <exec_depend>SpeechRecognition</exec_depend>
+  <exec_depend>google-generativeai</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros_packages/voice_assistant/voice_assistant/chat.py
+++ b/ros_packages/voice_assistant/voice_assistant/chat.py
@@ -19,6 +19,7 @@ from rclpy.publisher import Publisher
 from std_msgs.msg import String
 
 from public_api_client import public_voice_client
+from .chat_factory import chat_completion as factory_chat_completion
 
 # in future, this code will be prepended to the description in a chat-request
 # if it is specified that code should be generated. The text will contain
@@ -184,9 +185,9 @@ class ChatNode(Node):
             image_base64 = response.image_base64
 
         try:
-            # receive assistant-response in form of an iterable of tokens from the public-api
+            # receive assistant-response in form of an async iterable of tokens
             with self.public_voice_client_lock:
-                tokens = public_voice_client.chat_completion(
+                tokens = factory_chat_completion(
                     text=content,
                     description=description,
                     message_history=message_history,
@@ -213,7 +214,7 @@ class ChatNode(Node):
             # for tracking if a message is an update or a new message
             bool_update_chat_message: bool = False
 
-            for token in tokens:
+            async for token in tokens:
 
                 if prev_text is not None:
                     # publish the previously collected text in form of feedback

--- a/ros_packages/voice_assistant/voice_assistant/chat_factory.py
+++ b/ros_packages/voice_assistant/voice_assistant/chat_factory.py
@@ -1,0 +1,43 @@
+"""Factory to route chat requests to the correct provider."""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterable, Iterable, List, Optional
+
+from public_api_client import public_voice_client
+
+from .gemini_chat_async import gemini_chat_completion
+
+
+async def chat_completion(
+    *,
+    text: str,
+    description: str,
+    message_history: List[public_voice_client.PublicApiChatMessage],
+    public_api_token: str,
+    image_base64: Optional[str] = None,
+    model: str,
+) -> AsyncIterable[str]:
+    """Return tokens from the selected LLM model."""
+    if "gemini" in model.lower():
+        async for token in gemini_chat_completion(
+            text=text,
+            description=description,
+            message_history=message_history,
+            image_base64=image_base64,
+            model=model,
+            public_api_token=public_api_token,
+        ):
+            yield token
+    else:
+        # wrap synchronous generator in async iterator
+        tokens = public_voice_client.chat_completion(
+            text=text,
+            description=description,
+            message_history=message_history,
+            image_base64=image_base64,
+            model=model,
+            public_api_token=public_api_token,
+        )
+        for token in tokens:
+            yield token

--- a/ros_packages/voice_assistant/voice_assistant/gemini_chat_async.py
+++ b/ros_packages/voice_assistant/voice_assistant/gemini_chat_async.py
@@ -1,16 +1,17 @@
-"""Async streaming interface to Google's Gemini models."""
+"""Async interface to Google's Gemini Live API."""
 from __future__ import annotations
 
 import base64
 import os
 from io import BytesIO
-from typing import AsyncIterable, List, Optional
+from typing import AsyncIterable, Iterable, List, Optional
 
 from PIL import Image
 
 from public_api_client.public_voice_client import PublicApiChatMessage
 
 import google.generativeai as genai
+from google.generativeai import types
 
 
 GOOGLE_API_KEY_ENV = "GOOGLE_API_KEY"
@@ -39,25 +40,44 @@ async def gemini_chat_completion(
     image_base64: Optional[str],
     model: str,
     public_api_token: str,
+    audio_stream: Optional[Iterable[bytes]] = None,
 ) -> AsyncIterable[str]:
-    """Yield text tokens from Gemini asynchronously."""
+    """Yield text tokens from Gemini asynchronously.
+
+    If ``audio_stream`` is provided, its PCM chunks (16kHz, mono, 16-bit) are
+    streamed to the model using the Gemini Live API. Audio responses from the
+    model are ignored; only text is yielded to the caller.
+    """
 
     _configure_api_key()
 
-    history = _build_history(message_history)
-    model_obj = genai.GenerativeModel(model, system_instruction=description)
-    chat = model_obj.start_chat(history=history)
+    config = {
+        "response_modalities": ["AUDIO"],
+        "system_instruction": description,
+    }
 
-    parts: list[object] = [text]
-    if image_base64:
-        try:
-            image_data = base64.b64decode(image_base64)
-            parts.append(Image.open(BytesIO(image_data)))
-        except Exception:
-            # If image decoding fails, fall back to text only
-            pass
+    async with genai.Client().aio.live.connect(model=model, config=config) as session:
+        for msg in message_history:
+            await session.send(input=msg.content, end_of_turn=True)
 
-    response = await chat.send_message_async(parts, stream=True)
-    async for chunk in response:
-        if chunk.text:
-            yield chunk.text
+        parts: list[object] = [text]
+        if image_base64:
+            try:
+                image_data = base64.b64decode(image_base64)
+                parts.append(Image.open(BytesIO(image_data)))
+            except Exception:
+                pass
+
+        await session.send(input=parts if len(parts) > 1 else parts[0], end_of_turn=audio_stream is None)
+
+        if audio_stream is not None:
+            for chunk in audio_stream:
+                await session.send_realtime_input(
+                    audio=types.Blob(data=chunk, mime_type="audio/pcm;rate=16000")
+                )
+            await session.end_turn()
+
+        async for response in session.receive():
+            if response.text:
+                yield response.text
+

--- a/ros_packages/voice_assistant/voice_assistant/gemini_chat_async.py
+++ b/ros_packages/voice_assistant/voice_assistant/gemini_chat_async.py
@@ -1,12 +1,8 @@
 """Async interface to Google's Gemini Live API."""
 from __future__ import annotations
 
-import base64
 import os
-from io import BytesIO
 from typing import AsyncIterable, Iterable, List, Optional
-
-from PIL import Image
 
 from public_api_client.public_voice_client import PublicApiChatMessage
 
@@ -52,7 +48,6 @@ async def gemini_chat_completion(
     _configure_api_key()
 
     config = {
-        "response_modalities": ["AUDIO"],
         "system_instruction": description,
     }
 
@@ -60,15 +55,7 @@ async def gemini_chat_completion(
         for msg in message_history:
             await session.send(input=msg.content, end_of_turn=True)
 
-        parts: list[object] = [text]
-        if image_base64:
-            try:
-                image_data = base64.b64decode(image_base64)
-                parts.append(Image.open(BytesIO(image_data)))
-            except Exception:
-                pass
-
-        await session.send(input=parts if len(parts) > 1 else parts[0], end_of_turn=audio_stream is None)
+        await session.send(input=text, end_of_turn=audio_stream is None)
 
         if audio_stream is not None:
             for chunk in audio_stream:

--- a/ros_packages/voice_assistant/voice_assistant/gemini_chat_async.py
+++ b/ros_packages/voice_assistant/voice_assistant/gemini_chat_async.py
@@ -1,0 +1,63 @@
+"""Async streaming interface to Google's Gemini models."""
+from __future__ import annotations
+
+import base64
+import os
+from io import BytesIO
+from typing import AsyncIterable, List, Optional
+
+from PIL import Image
+
+from public_api_client.public_voice_client import PublicApiChatMessage
+
+import google.generativeai as genai
+
+
+GOOGLE_API_KEY_ENV = "GOOGLE_API_KEY"
+
+
+def _configure_api_key() -> None:
+    """Configure the API key for ``google-generativeai`` from the environment."""
+    api_key = os.getenv(GOOGLE_API_KEY_ENV)
+    if api_key:
+        genai.configure(api_key=api_key)
+
+
+def _build_history(messages: List[PublicApiChatMessage]) -> list[dict[str, object]]:
+    """Convert ``PublicApiChatMessage`` objects to Gemini chat history entries."""
+    return [
+        {"role": "user" if m.is_user else "model", "parts": [m.content]}
+        for m in messages
+    ]
+
+
+async def gemini_chat_completion(
+    *,
+    text: str,
+    description: str,
+    message_history: List[PublicApiChatMessage],
+    image_base64: Optional[str],
+    model: str,
+    public_api_token: str,
+) -> AsyncIterable[str]:
+    """Yield text tokens from Gemini asynchronously."""
+
+    _configure_api_key()
+
+    history = _build_history(message_history)
+    model_obj = genai.GenerativeModel(model, system_instruction=description)
+    chat = model_obj.start_chat(history=history)
+
+    parts: list[object] = [text]
+    if image_base64:
+        try:
+            image_data = base64.b64decode(image_base64)
+            parts.append(Image.open(BytesIO(image_data)))
+        except Exception:
+            # If image decoding fails, fall back to text only
+            pass
+
+    response = await chat.send_message_async(parts, stream=True)
+    async for chunk in response:
+        if chunk.text:
+            yield chunk.text

--- a/setup/dev_tools/health-check-pib.sh
+++ b/setup/dev_tools/health-check-pib.sh
@@ -116,7 +116,7 @@ fi
 if [ $run_python_package_check = $true ]; then
     echo -e "$new_line""$yellow_text_color""--- checking python packages ---""$reset_text_color"
 
-    pip_packages=([1]=depthai [2]=tinkerforge [3]=openai [4]=google-cloud-speech [5]=google-cloud-texttospeech [6]=pyaudio [7]=opencv-python [8]=setuptools)
+    pip_packages=([1]=depthai [2]=tinkerforge [3]=openai [4]=google-cloud-speech [5]=google-cloud-texttospeech [6]=pyaudio [7]=opencv-python [8]=setuptools [9]=google-generativeai)
     for package in "${pip_packages[@]}"
     do
         if ! pip show "$package" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- rename Gemini model to "Gemini 2.5 Flash"
- update database migration to insert renamed model
- add a chat factory and async Gemini chat implementation
- integrate new async chat into `ChatNode`
- improve Gemini async chat implementation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ament_flake8)*

------
https://chatgpt.com/codex/tasks/task_e_6870f4f90ec083319b0bc486a74b49fe