### PR TITLE
Implement persistent Gemini live chat sessions

### DIFF
--- a/ros_packages/requirements.txt
+++ b/ros_packages/requirements.txt
@@ -6,4 +6,4 @@ opencv-python >= 4.5.1.48
 depthai>=2.24.0.0
 numpy==1.26.3
 blobconverter==1.4.2
-google-generativeai
+google-genai

--- a/ros_packages/voice_assistant/package.xml
+++ b/ros_packages/voice_assistant/package.xml
@@ -15,7 +15,7 @@
   <exec_depend>google-cloud-texttospeech</exec_depend>
   <exec_depend>pyaudio</exec_depend>
   <exec_depend>SpeechRecognition</exec_depend>
-  <exec_depend>google-generativeai</exec_depend>
+  <exec_depend>google-genai</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros_packages/voice_assistant/voice_assistant/chat.py
+++ b/ros_packages/voice_assistant/voice_assistant/chat.py
@@ -194,6 +194,7 @@ class ChatNode(Node):
                     image_base64=image_base64,
                     model=personality.assistant_model.api_name,
                     public_api_token=self.token,
+                    chat_id=chat_id,
                 )
 
             # regex for indentifying sentences

--- a/ros_packages/voice_assistant/voice_assistant/chat_factory.py
+++ b/ros_packages/voice_assistant/voice_assistant/chat_factory.py
@@ -1,12 +1,13 @@
 """Factory to route chat requests to the correct provider."""
 from __future__ import annotations
 
-import asyncio
-from typing import AsyncIterable, Iterable, List, Optional
+from typing import AsyncIterable, List, Optional
 
 from public_api_client import public_voice_client
 
-from .gemini_chat_async import gemini_chat_completion
+from .gemini_chat_async import GeminiLiveSession
+
+_gemini_sessions: dict[str, GeminiLiveSession] = {}
 
 
 async def chat_completion(
@@ -17,17 +18,21 @@ async def chat_completion(
     public_api_token: str,
     image_base64: Optional[str] = None,
     model: str,
+    chat_id: str,
 ) -> AsyncIterable[str]:
     """Return tokens from the selected LLM model."""
     if "gemini" in model.lower():
-        async for token in gemini_chat_completion(
-            text=text,
-            description=description,
-            message_history=message_history,
-            image_base64=image_base64,
-            model=model,
-            public_api_token=public_api_token,
-        ):
+        session = _gemini_sessions.get(chat_id)
+        if session is None:
+            session = GeminiLiveSession(
+                description=description,
+                message_history=message_history,
+                image_base64=image_base64,
+                model=model,
+            )
+            _gemini_sessions[chat_id] = session
+
+        async for token in session.ask(text):
             yield token
     else:
         # wrap synchronous generator in async iterator

--- a/setup/dev_tools/health-check-pib.sh
+++ b/setup/dev_tools/health-check-pib.sh
@@ -116,7 +116,7 @@ fi
 if [ $run_python_package_check = $true ]; then
     echo -e "$new_line""$yellow_text_color""--- checking python packages ---""$reset_text_color"
 
-    pip_packages=([1]=depthai [2]=tinkerforge [3]=openai [4]=google-cloud-speech [5]=google-cloud-texttospeech [6]=pyaudio [7]=opencv-python [8]=setuptools [9]=google-generativeai)
+    pip_packages=([1]=depthai [2]=tinkerforge [3]=openai [4]=google-cloud-speech [5]=google-cloud-texttospeech [6]=pyaudio [7]=opencv-python [8]=setuptools [9]=google-genai)
     for package in "${pip_packages[@]}"
     do
         if ! pip show "$package" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- manage persistent sessions with Gemini Live API
- route Gemini chat requests through `GeminiLiveSession`
- pass chat ID when requesting a chat completion

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: ament_flake8)*

------
https://chatgpt.com/codex/tasks/task_e_6874de787b208331b5ee952cdce2b1f8